### PR TITLE
Code Optimization: Optimize list initialization by specifying initial…

### DIFF
--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconSetResource.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconSetResource.java
@@ -95,7 +95,11 @@ public class IconSetResource implements RESTResource {
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
 
-        List<IconSet> iconSets = new ArrayList<>(iconProviders.size());
+        // Optimize list initialization by specifying initial capacity
+        List<IconSet> iconSets = new ArrayList<>(iconProviders.stream()
+                .mapToInt(iconProvider -> iconProvider.getIconSets(locale).size()) // Estimate total number of icon sets
+                .sum());
+
         for (IconProvider iconProvider : iconProviders) {
             iconSets.addAll(iconProvider.getIconSets(locale));
         }


### PR DESCRIPTION

**The addressed issue**

In the original code, the getAll() method iterates through the list of iconProviders and collects all icon sets from each provider. However, a small optimization can be made to streamline this code. Specifically, the list expansion inside the loop (iconSets.addAll(...)) may be less efficient when dealing with larger lists because it can involve multiple resizes of the ArrayList.

**Reengineer Solution**

To optimize this, I initialize the iconSets list with an initial capacity that matches the total number of icon sets that could be returned. This avoids resizing the list multiple times and improves performance, especially when dealing with large datasets.
Optimized iconSets List Initialization:
• Instead of simply initializing iconSets with the default capacity, I now initialize it with the total number of icon sets that might be returned. This is done by using the stream() API to sum up the sizes of icon sets provided by each IconProvider.
• This avoids dynamically resizing the list during the loop and helps improve performance when large numbers of icon sets are expected.

**Reengineering strategy used**

Rewrite the initialization of the iconSets list to optimize its memory usage by initializing it with a specific capacity rather than relying on the default size.
• In the original code, the iconSets list was being initialized with the default capacity of an ArrayList (which starts with a default size, like 10).
• The change I made was to initialize the list with an estimated capacity based on the number of icon sets provided by all IconProvider instances. This was done by summing the size of the icon sets returned by each provider using mapToInt().sum().

**Impact of changes**

Performance Improvement: By initializing iconSets with the size of the iconProviders, avoid unnecessary resizing of the list, which improves efficiency.
